### PR TITLE
Fix for GL-S10 v2.1 ethernet clock

### DIFF
--- a/lib/network/Network.h
+++ b/lib/network/Network.h
@@ -148,7 +148,7 @@ const ethernet_settings ethernetBoards[] = {
     23,                   // eth_mdc,
     18,                   // eth_mdio,
     ETH_PHY_IP101,        // eth_type,
-    ETH_CLOCK_GPIO17_OUT  // eth_clk_mode
+    ETH_CLOCK_GPIO0_IN    // eth_clk_mode
   }
 };
 


### PR DESCRIPTION
Current configuration for GL-S10 v2.1 ethernet clk is wrong conducting to inconsistent connectivity.
See https://community.home-assistant.io/t/gl-s10-v2-1-packet-loss-issues/486575
Tested on my device: 0% packet loss!